### PR TITLE
Added packaging support and alternative input option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup
 setup(name='vnav',
     version='0.1',
     description='Script to parse DICOM files from a vNav series and convert them into motion scores',
-    url='https://github.com/hacevedo/parse_vNav_Motion',
+    url='https://github.com/MRIMotionCorrection/parse_vNav_Motion',
     author='Dylan Tisdall',
     author_email='mtisdall@mail.med.upenn.edu',
     license='MIT',
     packages=['vnav'],
-    install_requires=['pydicom'])
+    install_requires=['pydicom', 'numpy'])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(name='vnav',
+    version='0.1',
+    description='Script to parse DICOM files from a vNav series and convert them into motion scores',
+    url='https://github.com/hacevedo/parse_vNav_Motion',
+    author='Dylan Tisdall',
+    author_email='mtisdall@mail.med.upenn.edu',
+    license='MIT',
+    packages=['vnav'],
+    install_requires=['pydicom'])

--- a/vnav/__init__.py
+++ b/vnav/__init__.py
@@ -1,0 +1,1 @@
+from vnav.parse_vNav_Motion import parseMotion

--- a/vnav/parse_vNav_Motion.py
+++ b/vnav/parse_vNav_Motion.py
@@ -13,10 +13,10 @@ def readRotAndTrans(paths):
   files = list(itertools.chain.from_iterable([glob.glob(path) for path in paths]))
 
   head = [(np.array([1,0,0,0]),np.array([0,0,0]))]
-
   ds = sorted([pydicom.dcmread(x) for x in files], key=lambda dcm: dcm.AcquisitionNumber)
+  imageComments = [ str.split(x.ImageComments) for x in ds[1:] if 'ImageComments' in x ]
 
-  return list(itertools.chain.from_iterable([head, [(np.array(map(float, y[1:5])), map(float, y[6:9])) for y in [str.split(x.ImageComments) for x in ds[1:] if 'ImageComments' in x]]]))
+  return list(itertools.chain.from_iterable([head, [ (np.array(list(map(float, y[1:5]))), list(map(float, y[6:9]))) for y in imageComments] ]))
 
 def angleAxisToQuaternion(a):
   w = np.cos(a[0] / 2.0)
@@ -185,7 +185,7 @@ if __name__ == '__main__':
   output_type.add_argument('--max-scores', action='store_true', help='Print max motion over time.')
 
   args = parser.parse_args()
-
+  
   scores = parseMotion(readRotAndTrans(args.input), args.tr, args.radius)
 
   # Script output to STDOUT depending on "output_type"

--- a/vnav/parse_vNav_Motion.py
+++ b/vnav/parse_vNav_Motion.py
@@ -21,7 +21,7 @@ def readRotAndTrans(paths):
     ds = sorted([pydicom.dcmread(x) for x in files], key=lambda dcm: dcm.AcquisitionNumber)
     motion_strings = [ str.split(x.ImageComments) for x in ds[1:] ]
 
-  return list(itertools.chain.from_iterable([head, [ (np.array(map(float, y[1:5])), map(float, y[6:9])) for y in motion_strings ] ]))
+  return list(itertools.chain.from_iterable([head, [ (np.array(list(map(float, y[1:5]))), list(map(float, y[6:9]))) for y in motion_strings ] ]))
 
 def angleAxisToQuaternion(a):
   w = np.cos(a[0] / 2.0)

--- a/vnav/parse_vNav_Motion.py
+++ b/vnav/parse_vNav_Motion.py
@@ -13,10 +13,10 @@ def readRotAndTrans(paths):
   files = list(itertools.chain.from_iterable([glob.glob(path) for path in paths]))
 
   head = [(np.array([1,0,0,0]),np.array([0,0,0]))]
-  ds = sorted([pydicom.dcmread(x) for x in files], key=lambda dcm: dcm.AcquisitionNumber)
-  imageComments = [ str.split(x.ImageComments) for x in ds[1:] if 'ImageComments' in x ]
 
-  return list(itertools.chain.from_iterable([head, [ (np.array(list(map(float, y[1:5]))), list(map(float, y[6:9]))) for y in imageComments] ]))
+  ds = sorted([pydicom.dcmread(x) for x in files], key=lambda dcm: dcm.AcquisitionNumber)
+
+  return list(itertools.chain.from_iterable([head, [(np.array(map(float, y[1:5])), map(float, y[6:9])) for y in [str.split(x.ImageComments) for x in ds[1:] if 'ImageComments' in x]]]))
 
 def angleAxisToQuaternion(a):
   w = np.cos(a[0] / 2.0)
@@ -185,7 +185,7 @@ if __name__ == '__main__':
   output_type.add_argument('--max-scores', action='store_true', help='Print max motion over time.')
 
   args = parser.parse_args()
-  
+
   scores = parseMotion(readRotAndTrans(args.input), args.tr, args.radius)
 
   # Script output to STDOUT depending on "output_type"

--- a/vnav/parse_vNav_Motion.py
+++ b/vnav/parse_vNav_Motion.py
@@ -156,7 +156,7 @@ def diffTransformToRMSMotion(t, radius):
     np.dot(trans, trans)
     )
 
-def getMotionScores(input, tr, radius, mean_rms=False, mean_max=False, rms_scores=False, max_scores=False):
+def parseMotion(input, tr, radius, mean_rms=False, mean_max=False, rms_scores=False, max_scores=False):
     # Transform creation and differences
     transforms = [motionEntryToHomogeneousTransform(e) for e in readRotAndTrans(input)]
     diffTransforms = [ts[1] * np.linalg.inv(ts[0]) for ts in zip(transforms[0:], transforms[1:])]
@@ -198,4 +198,4 @@ if __name__ == '__main__':
   output_type.add_argument('--max-scores', action='store_true', help='Print max motion over time.')
 
   args = parser.parse_args()
-  getMotionScores(args.input, args.tr, args.radius, args.mean_rms, args.mean_max, args.rms_scores, args.max_scores)
+  parseMotion(args.input, args.tr, args.radius, args.mean_rms, args.mean_max, args.rms_scores, args.max_scores)

--- a/vnav/parse_vNav_Motion.py
+++ b/vnav/parse_vNav_Motion.py
@@ -13,15 +13,14 @@ def readRotAndTrans(paths):
   files = list(itertools.chain.from_iterable([glob.glob(path) for path in paths]))
 
   head = [(np.array([1,0,0,0]),np.array([0,0,0]))]
-  motion_strings = []
   if len(files) == 1 and files[0].endswith('.json'):
     with open(files[0]) as f:
-      motion_strings = [ x.split() for x in json.load(f)['vnavNumbers'][1:] ]
+      imageComments = [ x.split() for x in json.load(f)['vnavNumbers'][1:] if x is not None ]
   else:
     ds = sorted([pydicom.dcmread(x) for x in files], key=lambda dcm: dcm.AcquisitionNumber)
-    motion_strings = [ str.split(x.ImageComments) if 'ImageComments' in x else None for x in ds[1:] ]
+    imageComments = [ str.split(x.ImageComments) for x in ds[1:] if 'ImageComments' in x ]
 
-  return list(itertools.chain.from_iterable([head, [ (np.array(list(map(float, y[1:5]))), list(map(float, y[6:9]))) for y in motion_strings if y is not None] ]))
+  return list(itertools.chain.from_iterable([head, [ (np.array(list(map(float, y[1:5]))), list(map(float, y[6:9]))) for y in imageComments] ]))
 
 def angleAxisToQuaternion(a):
   w = np.cos(a[0] / 2.0)

--- a/vnav/parse_vNav_Motion.py
+++ b/vnav/parse_vNav_Motion.py
@@ -156,38 +156,46 @@ def diffTransformToRMSMotion(t, radius):
     np.dot(trans, trans)
     )
 
-parser = argparse.ArgumentParser(description='Parse DICOM files from a vNav series and convert them into different motion scores.')
+def getMotionScores(input, tr, radius, mean_rms=False, mean_max=False, rms_scores=False, max_scores=False):
+    # Transform creation and differences
+    transforms = [motionEntryToHomogeneousTransform(e) for e in readRotAndTrans(input)]
+    diffTransforms = [ts[1] * np.linalg.inv(ts[0]) for ts in zip(transforms[0:], transforms[1:])]
 
-parser.add_argument('--tr', required=True, type=float,
-                    help='Repetition Time (TR) of the parent sequence (i.e., the MPRAGE) expressed in seconds.')
-parser.add_argument('--input', nargs='+', required=True, type=os.path.abspath,
-                    help='A list of DICOM files that make up the vNav series (in chronological order), or a BIDS JSON sidecar containing extracted motion strings')
-parser.add_argument('--radius', nargs=1, required=True, type=float,
-                    help='Assumed brain radius in millimeters for estimating rotation distance.')
-output_type = parser.add_mutually_exclusive_group(required=True)
-output_type.add_argument('--mean-rms', action='store_true', help='Print time-averaged root mean square (RMS) motion.')
-output_type.add_argument('--mean-max', action='store_true', help='Print time-averaged max motion.')
-output_type.add_argument('--rms-scores', action='store_true', help='Print root mean square (RMS) motion over time.')
-output_type.add_argument('--max-scores', action='store_true', help='Print max motion over time.')
+    # Motion scores
+    rmsMotionScores = [diffTransformToRMSMotion(t, radius) for t in diffTransforms]
+    maxMotionScores = [diffTransformToMaxMotion(t, radius) for t in diffTransforms]
 
-args = parser.parse_args()
+    # Script output to STDOUT depending on "output_type"
+    scores = []
+    if mean_rms :
+      scores.append(np.mean(rmsMotionScores) * 60.0 / tr)
+    elif mean_max :
+      scores.append(np.mean(maxMotionScores) * 60.0 / tr)
+    elif rms_scores :
+      for score in rmsMotionScores:
+        scores.append(score)
+    elif max_scores :
+      for score in maxMotionScores:
+        scores.append(score)
 
-# Transform creation and differences
-transforms = [motionEntryToHomogeneousTransform(e) for e in readRotAndTrans(args.input)]
-diffTransforms = [ts[1] * np.linalg.inv(ts[0]) for ts in zip(transforms[0:], transforms[1:])]
+    print('\n'.join(map(str, scores)))
+    return scores
 
-# Motion scores
-rmsMotionScores = [diffTransformToRMSMotion(t, args.radius[0]) for t in diffTransforms]
-maxMotionScores = [diffTransformToMaxMotion(t, args.radius[0]) for t in diffTransforms]
 
-# Script output to STDOUT depending on "output_type"
-if args.mean_rms :
-  print np.mean(rmsMotionScores) * 60.0 / args.tr
-elif args.mean_max :
-  print np.mean(maxMotionScores) * 60.0 / args.tr
-elif args.rms_scores :
-  for score in rmsMotionScores:
-    print score
-elif args.max_scores :
-  for score in maxMotionScores:
-    print score
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Parse DICOM files from a vNav series and convert them into different motion scores.')
+
+  parser.add_argument('--tr', required=True, type=float,
+                      help='Repetition Time (TR) of the parent sequence (i.e., the MPRAGE) expressed in seconds.')
+  parser.add_argument('--input', nargs='+', required=True, type=os.path.abspath,
+                      help='A list of DICOM files that make up the vNav series (in chronological order), or a BIDS JSON sidecar containing extracted motion strings')
+  parser.add_argument('--radius', required=True, type=float,
+                      help='Assumed brain radius in millimeters for estimating rotation distance.')
+  output_type = parser.add_mutually_exclusive_group(required=True)
+  output_type.add_argument('--mean-rms', action='store_true', help='Print time-averaged root mean square (RMS) motion.')
+  output_type.add_argument('--mean-max', action='store_true', help='Print time-averaged max motion.')
+  output_type.add_argument('--rms-scores', action='store_true', help='Print root mean square (RMS) motion over time.')
+  output_type.add_argument('--max-scores', action='store_true', help='Print max motion over time.')
+
+  args = parser.parse_args()
+  getMotionScores(args.input, args.tr, args.radius, args.mean_rms, args.mean_max, args.rms_scores, args.max_scores)


### PR DESCRIPTION
This requests includes 2 changes:

- Support for packaging (as [discussed](https://github.com/MRIMotionCorrection/parse_vNav_Motion/issues/7) previously) - would be available for install with following command: pip install git+https://github.com/MRIMotionCorrection/parse_vNav_Motion#egg=vnav

- Support for using previously extracted motion strings (i.e. in a BIDS JSON sidecar) as an alternative input option


